### PR TITLE
Better keybindings for Linux

### DIFF
--- a/keymaps/term2.cson
+++ b/keymaps/term2.cson
@@ -14,6 +14,12 @@
   'ctrl-alt-up': 'term2:open-split-up'
   'ctrl-alt-down': 'term2:open-split-down'
 
+  'ctrl-k t t': 'term2:open'
+  'ctrl-k t right': 'term2:open-split-right'
+  'ctrl-k t left': 'term2:open-split-left'
+  'ctrl-k t up': 'term2:open-split-up'
+  'ctrl-k t down': 'term2:open-split-down'
+
   'cmd-k t t': 'term2:open'
   'cmd-k t right': 'term2:open-split-right'
   'cmd-k t left': 'term2:open-split-left'
@@ -23,5 +29,7 @@
 '.term2':
   'cmd-c': 'term2:copy'
   'ctrl-c': 'term2:copy'
+  'ctrl-insert': 'term2:copy'
   'cmd-v': 'term2:paste'
   'ctrl-v': 'term2:paste'
+  'shift-insert': 'term2:paste'


### PR DESCRIPTION
Added new key bindings for opening an instance of Term 2 (similar to the key bindings on OS X). Also added new key bindings for term2:copy and term2:paste.

None of the old key bindings work on most Linux distributions (e.g. Ubuntu), because they are already used by the desktop environment. Because of this, Atom never receives them or they have some unintended result.

This fixes #93.