### PR TITLE
Fix focus on click

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -135,7 +135,14 @@ module.exports =
     splitTerm: (direction)->
       openPanesInSameSplit = atom.config.get 'term2.openPanesInSameSplit'
       termView = @createTermView()
-      termView.on "click", => @focusedTerminal = termView
+      termView.on "click", =>
+
+        # get focus in the terminal
+        # avoid double click to get focus
+        termView.term.element.focus()
+        termView.term.focus()
+
+        @focusedTerminal = termView
       direction = capitalize direction
 
       splitter = =>


### PR DESCRIPTION
Now when you click on the pane, you actually get the focus directly,
without having to double click.

Close #108

Note: this doesn't fix the focus issue when you navigate using the keyboard cmd+k/cmd+arrow.