### PR TITLE
Update style configuration to use editor font-family

### DIFF
--- a/lib/TermView.coffee
+++ b/lib/TermView.coffee
@@ -93,6 +93,7 @@ class TermView extends View
   applyStyle: ->
     # remove background color in favor of the atom background
     @term.element.style.background = null
+    @term.element.style.fontFamily = atom.config.get('editor.fontFamily')
 
   attachEvents: ->
     @resizeToPane = @resizeToPane.bind this

--- a/lib/TermView.coffee
+++ b/lib/TermView.coffee
@@ -61,12 +61,10 @@ class TermView extends View
     term.on "data", (data)=> @input data
     term.open this.get(0)
 
-    # remove background color in favor of the atom background
-    term.element.style.background = null
-
     @input "#{runCommand}#{os.EOL}" if runCommand
     term.focus()
 
+    @applyStyle()
     @attachEvents()
     @resizeToPane()
 
@@ -91,6 +89,10 @@ class TermView extends View
 
   getIconName: ->
     "terminal"
+
+  applyStyle: ->
+    # remove background color in favor of the atom background
+    @term.element.style.background = null
 
   attachEvents: ->
     @resizeToPane = @resizeToPane.bind this

--- a/styles/term2.less
+++ b/styles/term2.less
@@ -6,8 +6,6 @@
 
 .term2 {
   .terminal {
-    font-family: Menlo, Monaco, Inconsolata, monospace;
-
     padding: 0;
 
     > div {


### PR DESCRIPTION
*Note: I'm assuming there is more work to be done here, this PR is meant to just start this conversation*

I'm not sure this use case applies to everyone, but in my opinion the sane default for `font-family` is to derive it from the editor config.

As you see below the solution is not quite as elegant as importing the core `ui-variables` or `syntax-variables` This method was inspired by the Atom Theme [Isotope-UI](https://github.com/braver/isotope-ui/blob/master/lib/config.coffee).