### PR TITLE
Add monospace font as default

### DIFF
--- a/styles/term2.less
+++ b/styles/term2.less
@@ -5,6 +5,7 @@
 @import "ui-variables";
 
 .term2 {
+  font-family: monospace;
   .terminal {
     padding: 0;
 


### PR DESCRIPTION
Not sure if this goes against any larger plans for font support in term2.
Fixes #167 by doing exactly what @jchamb2010 said in the same issue.